### PR TITLE
ci: split ff and chrome builds

### DIFF
--- a/.github/chromifyManifest.js
+++ b/.github/chromifyManifest.js
@@ -1,0 +1,20 @@
+/**
+ * Remove the 'applications' key from the manifest because Chrome cant handle foreign keys in the manifest
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const pathToManifest = path.resolve(`dist-chrome/manifest.json`);
+
+fs.access(pathToManifest, (err) => {
+  if (err) {
+    console.log('Manifest does not exist in Chrome build folder');
+  } else {
+    let manifest = fs.readFileSync(pathToManifest, 'utf-8');
+    manifest = JSON.parse(manifest);
+    delete manifest.applications;
+    fs.writeFileSync(pathToManifest, JSON.stringify(manifest, null, 4));
+    console.log('Removed applications key from manifest')
+  }
+});

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./OpenTitles.crx
+          asset_path: ./OpenTitles-Chrome.crx
           asset_name: OpenTitles.crx
           asset_content_type: application/x-chrome-extension
 
@@ -77,7 +77,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./OpenTitles.zip
+          asset_path: ./OpenTitles-Firefox.zip
           asset_name: OpenTitles.zip
           asset_content_type: application/zip
 

--- a/.gitignore
+++ b/.gitignore
@@ -63,14 +63,10 @@ typings/
 *.zip
 *.crx
 
-promo/
-
-server/media\.json
-
-client/media\.json
-
 edge/
 
 /dist
+/dist-chrome
+/dist-firefox
 
 .cache/

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 *'History' logo by Sugeng Santoso*
 
-[Chrome](https://chrome.google.com/webstore/detail/opentitles/ipcpballelfolmocdhfjijgmbljachog) / [Mozzarella Firefox](https://addons.mozilla.org/en-GB/firefox/addon/opentitles/) / Edge (Coming soon)
+[Chrome](https://chrome.google.com/webstore/detail/opentitles/ipcpballelfolmocdhfjijgmbljachog) / [Mozzarella Firefox](https://addons.mozilla.org/en-GB/firefox/addon/opentitles/)
 
 OpenTitles is a browser addon that currently tracks changes to over 40 news sites, such as nos.nl, nytimes.com and theguardian.com. It adds a button to the headlines on these sites. When clicked, this button will show all recent changes to the title of this article.
 

--- a/package.json
+++ b/package.json
@@ -4,11 +4,15 @@
   "version": "2.9.0",
   "scripts": {
     "test": "jasmine-ts --config=jasmine.config.json",
-    "build": "parcel build src/* --no-minify && tsc src/static/popup/popup.ts --outFile dist/popup/popup.js || true",
-    "package": "crx3 -z OpenTitles.zip -o OpenTitles.crx dist",
     "lint": "eslint \"./src/**/*.ts\" --max-warnings 2",
-    "publish-chrome": "webstore upload --source OpenTitles.zip --auto-publish --extension-id ipcpballelfolmocdhfjijgmbljachog --client-id $CWS_CLIENT_ID --client-secret $CWS_CLIENT_SECRET --refresh-token $CWS_REFRESH_TOKEN || true",
-    "publish-firefox": "web-ext-submit --api-key=$FF_API_KEY --api-secret=$FF_API_SECRET --source-dir dist || true"
+    "build": "npm run build-chrome && npm run build-firefox",
+    "build-chrome": "parcel build src/* --no-minify --out-dir dist-chrome && node ./.github/chromifyManifest.js && tsc src/static/popup/popup.ts --outFile dist-chrome/popup/popup.js || true",
+    "build-firefox": "parcel build src/* --no-minify --out-dir dist-firefox && tsc src/static/popup/popup.ts --outFile dist-firefox/popup/popup.js || true",
+    "package": "npm run package-chrome && npm run package-firefox",
+    "package-chrome": "crx3 -z OpenTitles-Chrome.zip -o OpenTitles-Chrome.crx dist-chrome",
+    "package-firefox": "crx3 -z OpenTitles-Firefox.zip -o OpenTitles-Chrome.crx dist-firefox",
+    "publish-chrome": "webstore upload --source OpenTitles-Chrome.zip --auto-publish --extension-id ipcpballelfolmocdhfjijgmbljachog --client-id $CWS_CLIENT_ID --client-secret $CWS_CLIENT_SECRET --refresh-token $CWS_REFRESH_TOKEN || true",
+    "publish-firefox": "web-ext-submit --api-key=$FF_API_KEY --api-secret=$FF_API_SECRET --source-dir dist-firefox || true"
   },
   "dependencies": {},
   "devDependencies": {

--- a/src/OpenTitlesBackground.ts
+++ b/src/OpenTitlesBackground.ts
@@ -8,7 +8,8 @@ const extapi = getBrowserAPI();
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
 extapi.runtime.onMessage.addListener((request: BackgroundMessage, sender: unknown, sendResponse: (response?: any) => void) => {
   if (request.type == 'getarticle') {
-    fetch(`${CONFIG.API_URL}/opentitles/article/${encodeURIComponent(request.medium)}/${encodeURIComponent(request.id)}`)
+    // See https://opentitles.info/ for all endpoints
+    fetch(`${CONFIG.API_URL}/v${CONFIG.API_VERSION}/country/${request.medium.lang}/org/${encodeURIComponent(request.medium.name)}/article/${encodeURIComponent(request.id)}`)
       .then((response) => response.json())
       .then((result) => sendResponse(result));
   }

--- a/src/OpenTitlesMainScript.ts
+++ b/src/OpenTitlesMainScript.ts
@@ -28,6 +28,8 @@ fetch(extapi.extension.getURL('/media.json'))
       });
 
       if (medium) {
+        // Assign country to medium
+        medium.lang = key;
         break;
       }
     }
@@ -43,10 +45,10 @@ fetch(extapi.extension.getURL('/media.json'))
 
 /**
  * Query the background script for the title history of an article.
- * @param {string} medium The name of the medium to which the article belongs.
+ * @param {MediumDefinition} medium The medium to which the article belongs.
  * @param {string} articleID The ID of the article to query, must belong to an article published by $medium.
  */
-const getArticle = async (medium: string, articleID: string): Promise<Article> => {
+const getArticle = async (medium: MediumDefinition, articleID: string): Promise<Article> => {
   return new Promise((resolve) => {
     (extapi as typeof chrome).runtime.sendMessage({
       type: 'getarticle',
@@ -76,7 +78,7 @@ const doWhenMediumIsFound = async (medium: MediumDefinition) => {
     return;
   }
 
-  getArticle(medium.name, id).then((titlehist) => {
+  getArticle(medium, id).then((titlehist) => {
     if (typeof (titlehist) !== 'object') {
       titlehist = JSON.parse(titlehist);
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,6 @@
 export const CONFIG = {
-  API_URL: 'https://floris.amsterdam',
+  API_URL: 'https://api.opentitles.info',
+  API_VERSION: 2,
   MAX_RETRIES: {
     TITLE: 3,
     ID: 3

--- a/src/domain/BackgroundMessage.ts
+++ b/src/domain/BackgroundMessage.ts
@@ -1,5 +1,7 @@
+import { MediumDefinition } from "./MediumDefinition";
+
 export interface BackgroundMessage {
   type: string;
-  medium: string;
+  medium: MediumDefinition;
   id: string;
 }

--- a/src/domain/MediumDefinition.ts
+++ b/src/domain/MediumDefinition.ts
@@ -1,5 +1,6 @@
 export interface MediumDefinition {
   name: string;
+  lang: string;
   prefix: string;
   suffix: string;
   feeds: string[];

--- a/src/static/popup/popup.ts
+++ b/src/static/popup/popup.ts
@@ -1,3 +1,5 @@
+// eslint-disable-next-line
+// @ts-nocheck
 (() => {
   'use strict';
 


### PR DESCRIPTION
Use separate build paths for Chrome and Firefox so we can adjust the manifest for Chrome