### PR TITLE
fix: use `browser_specific_settings` instead of `applications` in manifest

### DIFF
--- a/.github/actions/bump/index.js
+++ b/.github/actions/bump/index.js
@@ -60,7 +60,7 @@ Toolkit.run(async tools => {
       let manifest = fs.readFileSync('src/static/manifest.json', 'utf-8');
       manifest = JSON.parse(manifest);
       manifest.version = version;
-      fs.writeFileSync('src/static/manifest.json', JSON.stringify(manifest, null, 4));
+      fs.writeFileSync('src/static/manifest.json', JSON.stringify(manifest, null, 2));
 
       // Update changelog
       let changelog = fs.readFileSync('changelog.md', 'utf-8');

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,8 +6,6 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [master]
-  schedule:
-    - cron: '0 9 * * 4'
 
 jobs:
   analyze:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,6 @@ on:
     paths:
       - 'src/**'
       - '!src/static/manifest.json'
-  workflow_dispatch:
 
 jobs:
   release:

--- a/src/buildTrigger.txt
+++ b/src/buildTrigger.txt
@@ -1,2 +1,2 @@
 Change the contents of this file to trigger a build
-3
+4

--- a/src/static/manifest.json
+++ b/src/static/manifest.json
@@ -1,98 +1,93 @@
 {
-    "manifest_version": 3,
-    "name": "OpenTitles",
-    "short_name": "OpenTitles",
-    "author": "Floris de Bijl",
-    "description": "Show the changes to titles for over 40 news outlets.",
-    "version": "2.12.0",
-    "icons": {
-        "16": "icons/logo16.png",
-        "48": "icons/logo48.png",
-        "128": "icons/logo128.png"
-    },
-    "applications": {
-        "gecko": {
-            "id": "{46e1c7cd-4bfa-4bdb-949e-e8103f99dd9a}"
-        }
-    },
-    "action": {
-        "default_icon": "icons/logo48.png",
-        "default_title": "Click to suggest this website to OpenTitles",
-        "default_popup": "popup/popup.html"
-    },
-    "content_scripts": [
-        {
-            "matches": [
-                "https://*.nu.nl/*",
-                "https://*.nos.nl/*",
-                "https://*.jeugdjournaal.nl/*",
-                "https://*.ad.nl/*",
-                "https://*.bd.nl/*",
-                "https://*.ed.nl/*",
-                "https://*.tubantia.nl/*",
-                "https://*.bndestem.nl/*",
-                "https://*.pzc.nl/*",
-                "https://*.destentor.nl/*",
-                "https://*.gelderlander.nl/*",
-                "https://*.telegraaf.nl/*",
-                "https://*.tweakers.net/*",
-                "https://*.nrc.nl/*",
-                "https://*.volkskrant.nl/*",
-                "https://*.rtlnieuws.nl/*",
-                "https://*.trouw.nl/*",
-                "https://*.parool.nl/*",
-                "https://*.limburger.nl/*",
-                "https://*.fd.nl/*",
-                "https://*.dvhn.nl/*",
-                "https://*.hartvannederland.nl/*",
-                "https://*.lc.nl/*",
-                "https://*.rd.nl/*",
-                "https://*.bnr.nl/*",
-                "https://*.elsevierweekblad.nl/*",
-                "https://*.abcnews.go.com/*",
-                "https://*.cbsnews.com/*",
-                "https://*.cnn.com/*",
-                "https://*.msnbc.com/*",
-                "https://*.nytimes.com/*",
-                "https://*.latimes.com/*",
-                "https://*.usatoday.com/*",
-                "https://*.wsj.com/articles/*",
-                "https://*.washingtonpost.com/*",
-                "https://*.vice.com/*",
-                "https://*.huffingtonpost.com/*",
-                "https://*.tmz.com/*",
-                "https://*.newsweek.com/*",
-                "http://*.time.com/*",
-                "https://*.theguardian.com/*",
-                "https://*.reuters.com/*"
-            ],
-            "js": [
-                "OpenTitlesMainScript.js"
-            ],
-            "css": [
-                "style/OpenTitles.css"
-            ],
-            "run_at": "document_idle"
-        }
-    ],
-    "background": {
-        "service_worker": "OpenTitlesBackground.js"
-    },
-    "host_permissions": [
-        "https://api.opentitles.info/*"
-    ],
-    "permissions": [
-        "tabs"
-    ],
-    "web_accessible_resources": [
-        {
-            "resources": [
-                "media.json"
-            ],
-            "matches": [
-                "http://*/*",
-                "https://*/*"
-            ]
-        }
-    ]
+  "manifest_version": 3,
+  "name": "OpenTitles",
+  "short_name": "OpenTitles",
+  "author": "Floris de Bijl",
+  "description": "Show the changes to titles for over 40 news outlets.",
+  "version": "2.11.0",
+  "icons": {
+    "16": "icons/logo16.png",
+    "48": "icons/logo48.png",
+    "128": "icons/logo128.png"
+  },
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "{46e1c7cd-4bfa-4bdb-949e-e8103f99dd9a}"
+    }
+  },
+  "action": {
+    "default_icon": "icons/logo48.png",
+    "default_title": "Click to suggest this website to OpenTitles",
+    "default_popup": "popup/popup.html"
+  },
+  "content_scripts": [
+    {
+      "matches": [
+        "https://*.nu.nl/*",
+        "https://*.nos.nl/*",
+        "https://*.jeugdjournaal.nl/*",
+        "https://*.ad.nl/*",
+        "https://*.bd.nl/*",
+        "https://*.ed.nl/*",
+        "https://*.tubantia.nl/*",
+        "https://*.bndestem.nl/*",
+        "https://*.pzc.nl/*",
+        "https://*.destentor.nl/*",
+        "https://*.gelderlander.nl/*",
+        "https://*.telegraaf.nl/*",
+        "https://*.tweakers.net/*",
+        "https://*.nrc.nl/*",
+        "https://*.volkskrant.nl/*",
+        "https://*.rtlnieuws.nl/*",
+        "https://*.trouw.nl/*",
+        "https://*.parool.nl/*",
+        "https://*.limburger.nl/*",
+        "https://*.fd.nl/*",
+        "https://*.dvhn.nl/*",
+        "https://*.hartvannederland.nl/*",
+        "https://*.lc.nl/*",
+        "https://*.rd.nl/*",
+        "https://*.bnr.nl/*",
+        "https://*.elsevierweekblad.nl/*",
+        "https://*.abcnews.go.com/*",
+        "https://*.cbsnews.com/*",
+        "https://*.cnn.com/*",
+        "https://*.msnbc.com/*",
+        "https://*.nytimes.com/*",
+        "https://*.latimes.com/*",
+        "https://*.usatoday.com/*",
+        "https://*.wsj.com/articles/*",
+        "https://*.washingtonpost.com/*",
+        "https://*.vice.com/*",
+        "https://*.huffingtonpost.com/*",
+        "https://*.tmz.com/*",
+        "https://*.newsweek.com/*",
+        "http://*.time.com/*",
+        "https://*.theguardian.com/*",
+        "https://*.reuters.com/*"
+      ],
+      "js": [
+        "OpenTitlesMainScript.js"
+      ],
+      "css": [
+        "style/OpenTitles.css"
+      ],
+      "run_at": "document_idle"
+    }
+  ],
+  "background": {
+    "service_worker": "OpenTitlesBackground.js"
+  },
+  "host_permissions": [
+    "https://api.opentitles.info/*"
+  ],
+  "permissions": [
+    "tabs"
+  ],
+  "web_accessible_resources": [
+    {
+      "resources": ["media.json"],
+      "matches": ["http://*/*", "https://*/*"]
+    }
+  ]
 }


### PR DESCRIPTION
See https://discourse.mozilla.org/t/consider-renaming-the-webextensions-applications-manifest-key-to-browser-specific-settings/31394